### PR TITLE
Mark alerts as triggered in DB when timer > threshold_timer

### DIFF
--- a/app/cito_engine/models.py
+++ b/app/cito_engine/models.py
@@ -198,11 +198,11 @@ class EventActionCounter(models.Model):
         if self.timer > self.event_action.threshold_timer:
             # If threshold was one incident in Y secs, we have to return True
             if self.event_action.threshold_count == 1:
-		self.is_triggered = True
+                self.is_triggered = True
                 self._reset_all()
                 return True
 
-	    # else
+            # else
             self.is_triggered = False
             self._reset_all()
 

--- a/app/cito_engine/models.py
+++ b/app/cito_engine/models.py
@@ -194,17 +194,23 @@ class EventActionCounter(models.Model):
 
     @property
     def is_action_required(self):
+        # Got an incident outside the timer
+        if self.timer > self.event_action.threshold_timer:
+            # If threshold was one incident in Y secs, we have to return True
+            if self.event_action.threshold_count == 1:
+		self.is_triggered = True
+                self._reset_all()
+                return True
+
+	    # else
+            self.is_triggered = False
+            self._reset_all()
+
         # Check if X incidents occured in Y seconds
-        if self.count >= self.event_action.threshold_count and self.timer <= self.event_action.threshold_timer:
+        elif self.count >= self.event_action.threshold_count and self.timer <= self.event_action.threshold_timer:
             if not self.is_triggered:
                 self.is_triggered = True
                 self.save()
-                return True
-        # Got an incident outside the timer
-        elif self.timer > self.event_action.threshold_timer:
-            # If threshold was one incident in Y secs, we have to return True
-            self._reset_all()
-            if self.event_action.threshold_count == 1:
                 return True
 
         return False
@@ -212,7 +218,6 @@ class EventActionCounter(models.Model):
     def _reset_all(self):
         self.count = 1
         self.timer = 0
-        self.is_triggered = False
         self.save()
 
     def __unicode__(self):


### PR DESCRIPTION
**Current problem:** 
When `citoengine` receives multiple alerts of the same event within the same second, duplicated event actions are triggered.

**How to replicate?**
- Create an event action.
- Set `Threshold Count` to `1` and `Threshold Timer` to `60`.
- Use `event_publisher.py` to send multiple alerts to `citoengine` within a second. 
- You will notice the corresponding event action is triggered more than once.

**Proposed Fix:**
- Reorder the if-else statement in `def is_action_required(self)`: `if self.timer > self.event_action.threshold_timer` has to be the first condition.
- Mark alert as triggered and save to database when threshold is reached (when timer exceeds configured threshold timing).